### PR TITLE
Fix a problem where host cannot be modified

### DIFF
--- a/request.go
+++ b/request.go
@@ -282,7 +282,11 @@ func (req *Request) makeRequest(verb, url string, payloads *bytes.Buffer) (*Resp
 
 	// set headers from Headers method
 	for key, val := range req.headers {
-		request.Header.Set(key, val)
+		if key == "Host" {
+			request.Host = val
+		}else{
+			request.Header.Set(key, val)
+		}
 	}
 
 	//request.Close = true

--- a/request.go
+++ b/request.go
@@ -282,13 +282,12 @@ func (req *Request) makeRequest(verb, url string, payloads *bytes.Buffer) (*Resp
 
 	// set headers from Headers method
 	for key, val := range req.headers {
-		if key == "Host" {
-			request.Host = val
-		}else{
-			request.Header.Set(key, val)
-		}
+		request.Header.Set(key, val)
 	}
 
+	if val,ok := req.headers["Host"]; ok  {
+		request.Host = val
+	}
 	//request.Close = true
 	resp, err := client.Do(request)
 


### PR DESCRIPTION
Fixed the problem that the host could not be modified because the host in the net library was put into the host attribute of request

Path: net/http/request.go
type Request struct {
        // For server requests, Host specifies the host on which the
	// URL is sought. For HTTP/1 (per RFC 7230, section 5.4), this
	// is either the value of the "Host" header or the host name
	// given in the URL itself. For HTTP/2, it is the value of the
	// ":authority" pseudo-header field.
	// It may be of the form "host:port". For international domain
	// names, Host may be in Punycode or Unicode form. Use
	// golang.org/x/net/idna to convert it to either format if
	// needed.
	// To prevent DNS rebinding attacks, server Handlers should
	// validate that the Host header has a value for which the
	// Handler considers itself authoritative. The included
	// ServeMux supports patterns registered to particular host
	// names and thus protects its registered Handlers.
	//
	// For client requests, Host optionally overrides the Host
	// header to send. If empty, the Request.Write method uses
	// the value of URL.Host. Host may contain an international
	// domain name.
	Host string
}

